### PR TITLE
Lock flip-button while card flips

### DIFF
--- a/src/app/play-dialog/play-dialog.component.html
+++ b/src/app/play-dialog/play-dialog.component.html
@@ -19,9 +19,9 @@
     </div>
 
     <mat-dialog-actions align="end" *ngIf="!finished">
-      <button mat-button mat-raised-button color="accent" (click)="nextCard(false)">Didn't know 😖</button>
-      <button mat-button mat-raised-button color="accent" cdkFocusInitial (click)="flip()">Flip 🎴</button>
-      <button mat-button mat-raised-button color="accent" (click)="nextCard(true)">Knew it 😊</button>
+      <button mat-button mat-raised-button color="accent" class="cardActionBtn" (click)="nextCard(false)">Didn't know 😖</button>
+      <button mat-button mat-raised-button color="accent" class="cardActionBtn" cdkFocusInitial (click)="flip()">Flip 🎴</button>
+      <button mat-button mat-raised-button color="accent" class="cardActionBtn" (click)="nextCard(true)">Knew it 😊</button>
     </mat-dialog-actions>
   </div>
 </ng-template>

--- a/src/app/play-dialog/play-dialog.component.ts
+++ b/src/app/play-dialog/play-dialog.component.ts
@@ -51,7 +51,8 @@ export class PlayDialogComponent {
   }
 
   flip = () => {
-    gsap.from('#question', { rotationY: -180 })
+    gsap.from('#question', { rotationY: -180 });
+    gsap.from('.cardActionBtn', { pointerEvents: 'none', opacity: .5 });
     switch (this.cardSide) {
       case CardSide.top:
         this.cardSide = CardSide.bottom


### PR DESCRIPTION
As part of the flipping card action, buttons will not be clickable and its opacity will be also reduced till the cards end up the flip action.